### PR TITLE
New project module, error handling, update capabilities, ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The modules use [metal-python](https://github.com/metal-stack/metal-python) for 
 | [metal_firewall](library/metal_firewall.py) | Manages metal-stack firewall entities                         | metal-python      |
 | [metal_machine](library/metal_machine.py)   | Manages metal-stack machine entities                         | metal-python      |
 | [metal_network](library/metal_network.py)   | Manages metal-stack network entities                         | metal-python      |
+| [metal_project](library/metal_project.py)   | Manages metal-stack project entities                         | metal-python      |
 
 ## Dynamic Inventories
 
@@ -31,7 +32,7 @@ It's convenient to use ansible-galaxy in order to use this project. For your pro
 
 ```yaml
 - src: https://github.com/metal-stack/metal-ansible-modules.git
-  name: metal-modules
+  name: metal-ansible-modules
   version: master 
 ```
 
@@ -49,5 +50,5 @@ Then reference the roles in your playbooks like this:
   connection: local
   gather_facts: no
   roles:
-    - metal-modules
+    - metal-ansible-modules
 ```

--- a/inventory/metal.py
+++ b/inventory/metal.py
@@ -62,7 +62,7 @@ def parse_arguments():
 
 
 def host_list():
-    d = Driver(url=URL, bearer=TOKEN, hmac_key=HMAC)
+    d = Driver(url=URL, bearer=TOKEN, hmac_key=HMAC, hmac_user="Metal-Edit")
 
     request = models.V1MachineFindRequest()
     scope_filters = CONFIG.get("scope_filters", [])

--- a/inventory/metal.py
+++ b/inventory/metal.py
@@ -22,9 +22,10 @@ if os.path.isfile(CONFIG_PATH):
     with open(CONFIG_PATH, "r") as f:
         CONFIG = yaml.safe_load(f)
 
-URL = os.environ.get("METAL_ANSIBLE_INVENTORY_URL", CONFIG.get("url"))
-TOKEN = os.environ.get("METAL_ANSIBLE_INVENTORY_TOKEN", CONFIG.get("token"))
-HMAC = os.environ.get("METAL_ANSIBLE_INVENTORY_HMAC", CONFIG.get("hmac"))
+URL = CONFIG.get("url", os.environ.get("METAL_ANSIBLE_INVENTORY_URL", os.environ.get("METALCTL_URL")))
+TOKEN = CONFIG.get("token", os.environ.get("METAL_ANSIBLE_INVENTORY_TOKEN"))
+HMAC = CONFIG.get("hmac", os.environ.get("METAL_ANSIBLE_INVENTORY_HMAC", os.environ.get("METALCTL_HMAC")))
+HMAC_USER = CONFIG.get("hmac_user", "Metal-Edit")
 
 ANSIBLE_CI_MANAGED_KEY = "ci.metal-stack.io/manager"
 ANSIBLE_CI_MANAGED_VALUE = "ansible"
@@ -62,7 +63,7 @@ def parse_arguments():
 
 
 def host_list():
-    d = Driver(url=URL, bearer=TOKEN, hmac_key=HMAC, hmac_user="Metal-Edit")
+    d = Driver(url=URL, bearer=TOKEN, hmac_key=HMAC, hmac_user=HMAC_USER)
 
     request = models.V1MachineFindRequest()
     scope_filters = CONFIG.get("scope_filters", [])

--- a/inventory/metal.py
+++ b/inventory/metal.py
@@ -159,11 +159,14 @@ def host_list():
             metal_tags=tags,
         )
 
-        _append_to_inventory(inventory, project_id, hostname)
-        _append_to_inventory(inventory, size_id, hostname)
-        _append_to_inventory(inventory, partition_id, hostname)
-        _append_to_inventory(inventory, image_id, hostname)
-        _append_to_inventory(inventory, "metal", hostname)
+        if is_machine:
+            _append_to_inventory(inventory, project_id, hostname)
+            _append_to_inventory(inventory, size_id, hostname)
+            _append_to_inventory(inventory, partition_id, hostname)
+            _append_to_inventory(inventory, image_id, hostname)
+            _append_to_inventory(inventory, "metal", hostname)
+        else:
+            _append_to_inventory(inventory, "metal-firewalls", hostname)
 
         if internal_ip:
             machine_meta[hostname]["metal_internal_ip"] = internal_ip

--- a/inventory/metal.py
+++ b/inventory/metal.py
@@ -147,6 +147,7 @@ def host_list():
 
         machine_meta[hostname] = dict(
             ansible_host=ansible_host,
+            ansible_user="metal",
             metal_id=id,
             metal_name=name,
             metal_hostname=hostname,

--- a/inventory/metal.py
+++ b/inventory/metal.py
@@ -14,22 +14,41 @@ try:
 except ImportError:
     METAL_PYTHON_AVAILABLE = False
 
-CONFIG_PATH = os.environ.get("METAL_ANSIBLE_INVENTORY_CONFIG",
-                             os.path.join(os.path.dirname(__file__), "metal_config.yaml"))
-
-CONFIG = dict()
-if os.path.isfile(CONFIG_PATH):
-    with open(CONFIG_PATH, "r") as f:
-        CONFIG = yaml.safe_load(f)
-
-URL = CONFIG.get("url", os.environ.get("METAL_ANSIBLE_INVENTORY_URL", os.environ.get("METALCTL_URL")))
-TOKEN = CONFIG.get("token", os.environ.get("METAL_ANSIBLE_INVENTORY_TOKEN"))
-HMAC = CONFIG.get("hmac", os.environ.get("METAL_ANSIBLE_INVENTORY_HMAC", os.environ.get("METALCTL_HMAC")))
-HMAC_USER = CONFIG.get("hmac_user", "Metal-Edit")
-
 ANSIBLE_CI_MANAGED_KEY = "ci.metal-stack.io/manager"
 ANSIBLE_CI_MANAGED_VALUE = "ansible"
 ANSIBLE_CI_MANAGED_TAG = ANSIBLE_CI_MANAGED_KEY + "=" + ANSIBLE_CI_MANAGED_VALUE
+
+
+class Configuration:
+    CONFIG_PATH = os.environ.get("METAL_ANSIBLE_INVENTORY_CONFIG",
+                                 os.path.join(os.path.dirname(__file__), "metal_config.yaml"))
+
+    def __init__(self):
+        self._config = dict()
+        if os.path.isfile(Configuration.CONFIG_PATH):
+            with open(Configuration.CONFIG_PATH, "r") as f:
+                self._config = yaml.safe_load(f)
+
+    def url(self):
+        return self._config.get("url", os.environ.get("METAL_ANSIBLE_INVENTORY_URL", os.environ.get("METALCTL_URL")))
+
+    def token(self):
+        return self._config.get("token", os.environ.get("METAL_ANSIBLE_INVENTORY_TOKEN"))
+
+    def hmac(self):
+        return self._config.get("hmac", os.environ.get("METAL_ANSIBLE_INVENTORY_HMAC", os.environ.get("METALCTL_HMAC")))
+
+    def hmac_user(self):
+        return self._config.get("hmac_user", "Metal-Edit")
+
+    def external_network_id(self):
+        return self._config.get("external_network_id", "internet")
+
+    def scope_filters(self):
+        return self._config.get("scope_filters", [])
+
+    def static_machine_ip_mapping(self):
+        return self._config.get("static_machine_ip_mapping", dict())
 
 
 def run():
@@ -63,11 +82,12 @@ def parse_arguments():
 
 
 def host_list():
-    d = Driver(url=URL, bearer=TOKEN, hmac_key=HMAC, hmac_user=HMAC_USER)
+    c = Configuration()
+
+    d = Driver(url=c.url(), bearer=c.token(), hmac_key=c.hmac(), hmac_user=c.hmac_user())
 
     request = models.V1MachineFindRequest()
-    scope_filters = CONFIG.get("scope_filters", [])
-    for scope_filter in scope_filters:
+    for scope_filter in c.scope_filters():
         request.__setattr__(scope_filter["name"], scope_filter["value"])
 
     machines = MachineApi(api_client=d.client).find_machines(request)
@@ -76,37 +96,41 @@ def host_list():
     machine_meta = dict()
     inventory = {"_meta": dict(hostvars=machine_meta)}
 
-    static_machine_ip_mapping = CONFIG.get("static_machine_ip_mapping", dict())
-
     project_map = dict()
     for project in projects:
         project_map[project.meta.id] = project
 
+    static_machine_ip_mapping = c.static_machine_ip_mapping()
+
     for machine in machines:
-        id = machine.id
-        description = machine.description
+        if ANSIBLE_CI_MANAGED_TAG not in machine.tags:
+            continue
+
+        if not machine.id or machine.allocation is None:
+            continue
+
         rack_id = machine.rackid
         allocation = machine.allocation
         size_id = machine.size.id if machine.size else None
         partition_id = machine.partition.id if machine.partition else None
         tags = machine.tags
 
-        if ANSIBLE_CI_MANAGED_TAG not in tags:
-            continue
-
-        if allocation is None or not id:
-            continue
-
+        description = allocation.description
         networks = allocation.networks
         console_password = allocation.console_password
         name = allocation.name
         hostname = allocation.hostname
         project_id = allocation.project
         tenant_id = project_map.get(project_id).tenant_id
-        image = allocation.image
-        image_id = None
-        if image:
-            image_id = image.id
+
+        machine_event_log = []
+        if machine.events and machine.events.log:
+            for e in machine.events.log:
+                machine_event_log.append(dict(
+                    event=e.event,
+                    message=e.message,
+                    time=str(e.time),
+                ))
 
         internal_ip = None
         for network in networks:
@@ -119,7 +143,7 @@ def host_list():
         # TODO: It is somehow hard to determine the IP of the machine to connect with from the internet...
         external_ip = None
         for network in networks:
-            is_external = True if "internet" in network.networkid else False
+            is_external = True if c.external_network_id() in network.networkid else False
             if is_external:
                 external_ips = network.ips
                 if len(external_ips) > 0:
@@ -135,29 +159,39 @@ def host_list():
         is_machine = False
         is_firewall = False
 
-        # TODO: Can be replaced when we have https://github.com/metal-stack/metal-api/issues/24
+        image = allocation.image
+        image_id = None
+        image_expiration_date = None
         if image:
-            image_features = image.features
-
-            if "firewall" in image_features:
+            image_id = image.id
+            image_expiration_date = str(image.expiration_date)
+            # TODO: Can be replaced when we have https://github.com/metal-stack/metal-api/issues/24
+            if "firewall" in image.features:
                 if len(networks) > 1:
                     is_firewall = True
-            if "machine" in image_features:
+            if "machine" in image.features:
                 is_machine = True
 
         machine_meta[hostname] = dict(
             ansible_host=ansible_host,
             ansible_user="metal",
-            metal_id=id,
+            metal_allocated_at=str(allocation.created),
+            metal_id=machine.id,
             metal_name=name,
+            metal_event_log=machine_event_log,
             metal_hostname=hostname,
             metal_description=description,
             metal_rack_id=rack_id,
-            metal_project_id=project_id,
+            metal_partition=partition_id,
+            metal_project=project_id,
+            metal_size=size_id,
+            metal_image=image_id,
+            metal_image_expiration=image_expiration_date,
             metal_console_password=console_password,
-            metal_tenant_id=tenant_id,
+            metal_tenant=tenant_id,
             metal_is_firewall=is_firewall,
             metal_is_machine=is_machine,
+            metal_internal_ip=internal_ip,
             metal_tags=tags,
         )
 
@@ -166,18 +200,10 @@ def host_list():
             _append_to_inventory(inventory, size_id, hostname)
             _append_to_inventory(inventory, partition_id, hostname)
             _append_to_inventory(inventory, image_id, hostname)
+            _append_to_inventory(inventory, rack_id, hostname)
             _append_to_inventory(inventory, "metal", hostname)
         else:
             _append_to_inventory(inventory, "metal-firewalls", hostname)
-
-        if internal_ip:
-            machine_meta[hostname]["metal_internal_ip"] = internal_ip
-        if size_id:
-            machine_meta[hostname]["metal_size_id"] = size_id
-        if partition_id:
-            machine_meta[hostname]["metal_partition_id"] = partition_id
-        if image_id:
-            machine_meta[hostname]["metal_image_id"] = image_id
 
         if hostname in static_machine_ip_mapping:
             machine_meta[hostname]["ansible_host"] = static_machine_ip_mapping[hostname]

--- a/library/metal_firewall.py
+++ b/library/metal_firewall.py
@@ -3,6 +3,7 @@
 try:
     from metal_python.api import FirewallApi, MachineApi
     from metal_python import models
+    from metal_python import rest
 
     METAL_PYTHON_AVAILABLE = True
 except ImportError:
@@ -180,7 +181,11 @@ class Instance(object):
             allocation_name=self._name,
             allocation_project=self._project,
         )
-        firewalls = self._api_client.find_firewalls(r)
+        try:
+            firewalls = self._api_client.find_firewalls(r)
+        except rest.ApiException as e:
+            self._module.fail_json(msg="request to metal-api failed", error=str(e))
+            return
 
         if len(firewalls) > 1:
             self._module.fail_json(

--- a/library/metal_firewall.py
+++ b/library/metal_firewall.py
@@ -29,7 +29,6 @@ version_added: "2.8"
 description:
     - Manages firewall entities in the metal-api.
     - Requires metal_python to be installed.
-    - Cannot update entities.
 
 options:
     id:
@@ -162,14 +161,14 @@ class Instance(object):
             if self._firewall:
                 return
 
-            self._firewall_allocate()
+            self._allocate()
             self.changed = True
 
         elif self._state == "absent":
             if not self.id:
                 self._module.fail_json(msg="id is a required argument when state is absent")
             if self._firewall:
-                self._firewall_free()
+                self._free()
                 self.changed = True
 
     def _find(self):
@@ -197,7 +196,7 @@ class Instance(object):
             self._firewall = firewalls[0]
             self.id = self._firewall.id
 
-    def _firewall_allocate(self):
+    def _allocate(self):
         networks = list()
         for n in self._networks:
             networks.append(models.V1MachineAllocationNetwork(autoacquire=True, networkid=n))
@@ -220,16 +219,23 @@ class Instance(object):
             user_data=self._userdata,
         )
 
-        self._firewall = self._api_client.allocate_firewall(r)
+        try:
+            self._firewall = self._api_client.allocate_firewall(r)
+        except rest.ApiException as e:
+            self._module.fail_json(msg="request to metal-api failed", error=str(e))
+
         self.id = self._firewall.id
 
-    def _firewall_free(self):
+    def _free(self):
         if ANSIBLE_CI_MANAGED_TAG not in self._firewall.tags:
             self._module.fail_json(msg="entity does not have label attached: %s" % ANSIBLE_CI_MANAGED_TAG,
                                    project=self._project,
                                    name=self._name)
 
-        self._machine_api_client.free_machine(self.id)
+        try:
+            self._machine_api_client.free_machine(self.id)
+        except rest.ApiException as e:
+            self._module.fail_json(msg="request to metal-api failed", error=str(e))
 
 
 def main():

--- a/library/metal_ip.py
+++ b/library/metal_ip.py
@@ -29,7 +29,6 @@ version_added: "2.8"
 description:
     - Manages ip entities in the metal-api.
     - Requires metal_python to be installed.
-    - Cannot update entities.
 
 options:
     name:
@@ -135,16 +134,17 @@ class Instance(object):
 
         if self._state == "present":
             if self._ip:
+                self._update()
                 return
 
-            self._ip_allocate()
+            self._allocate()
             self.changed = True
 
         elif self._state == "absent":
             if not self.ip_address:
                 self._module.fail_json(msg="ip is a required argument when state is absent")
             if self._ip:
-                self._ip_free()
+                self._free()
                 self.changed = True
 
     def _find(self):
@@ -158,7 +158,36 @@ class Instance(object):
                 self._module.fail_json(msg="request to metal-api failed", error=str(e))
                 return
 
-    def _ip_allocate(self):
+    def _update(self):
+        r = models.V1IPUpdateRequest(
+            ipaddress=self.ip_address,
+            type=self._ip.type,
+        )
+
+        if self._ip.description != self._description:
+            self.changed = True
+            r.description = self._description
+
+        if self._ip.name != self._name:
+            self.changed = True
+            r.name = self._name
+
+        self._tags.append(ANSIBLE_CI_MANAGED_TAG)
+        if self._ip.tags != self._tags:
+            self.changed = True
+            r.tags = self._tags
+
+        if self._ip.type != self._type:
+            self.changed = True
+            r.type = self._type
+
+        if self.changed:
+            try:
+                self._ip = self._api_client.update_ip(r)
+            except rest.ApiException as e:
+                self._module.fail_json(msg="request to metal-api failed", error=str(e))
+
+    def _allocate(self):
         self._tags.append(ANSIBLE_CI_MANAGED_TAG)
 
         r = models.V1IPAllocateRequest(
@@ -170,16 +199,23 @@ class Instance(object):
             type=self._type
         )
 
-        self._ip = self._api_client.allocate_ip(r)
+        try:
+            self._ip = self._api_client.allocate_ip(r)
+        except rest.ApiException as e:
+            self._module.fail_json(msg="request to metal-api failed", error=str(e))
+
         self.ip_address = self._ip.ipaddress
 
-    def _ip_free(self):
+    def _free(self):
         if ANSIBLE_CI_MANAGED_TAG not in self._ip.tags:
             self._module.fail_json(msg="entity does not have label attached: %s" % ANSIBLE_CI_MANAGED_TAG,
                                    project=self._project,
                                    name=self._name)
 
-        self._api_client.free_ip(self.ip_address)
+        try:
+            self._api_client.free_ip(self.ip_address)
+        except rest.ApiException as e:
+            self._module.fail_json(msg="request to metal-api failed", error=str(e))
 
 
 def main():

--- a/library/metal_ip.py
+++ b/library/metal_ip.py
@@ -154,8 +154,9 @@ class Instance(object):
         try:
             self._ip = self._api_client.find_ip(self.ip_address)
         except rest.ApiException as e:
-            self._module.fail_json(msg="request to metal-api failed", error=str(e))
-            return
+            if e.status != 404:
+                self._module.fail_json(msg="request to metal-api failed", error=str(e))
+                return
 
     def _ip_allocate(self):
         self._tags.append(ANSIBLE_CI_MANAGED_TAG)

--- a/library/metal_ip.py
+++ b/library/metal_ip.py
@@ -3,6 +3,7 @@
 try:
     from metal_python.api import IpApi
     from metal_python import models
+    from metal_python import rest
 
     METAL_PYTHON_AVAILABLE = True
 except ImportError:
@@ -150,7 +151,11 @@ class Instance(object):
         if not self.ip_address:
             return
 
-        self._ip = self._api_client.find_ip(self.ip_address)
+        try:
+            self._ip = self._api_client.find_ip(self.ip_address)
+        except rest.ApiException as e:
+            self._module.fail_json(msg="request to metal-api failed", error=str(e))
+            return
 
     def _ip_allocate(self):
         self._tags.append(ANSIBLE_CI_MANAGED_TAG)

--- a/library/metal_machine.py
+++ b/library/metal_machine.py
@@ -3,6 +3,7 @@
 try:
     from metal_python.api import MachineApi
     from metal_python import models
+    from metal_python import rest
 
     METAL_PYTHON_AVAILABLE = True
 except ImportError:
@@ -179,7 +180,11 @@ class Instance(object):
             allocation_name=self._name,
             allocation_project=self._project,
         )
-        machines = self._api_client.find_machines(r)
+        try:
+            machines = self._api_client.find_machines(r)
+        except rest.ApiException as e:
+            self._module.fail_json(msg="request to metal-api failed", error=str(e))
+            return
 
         if len(machines) > 1:
             self._module.fail_json(

--- a/library/metal_machine.py
+++ b/library/metal_machine.py
@@ -70,6 +70,7 @@ options:
     networks:
         description:
             - The networks of the machine.
+            - IP acquisition mode can be specified by adding :auto or :noauto to the network name.
         required: false   
     ips:
         description:
@@ -199,7 +200,20 @@ class Instance(object):
     def _machine_allocate(self):
         networks = list()
         for n in self._networks:
-            networks.append(models.V1MachineAllocationNetwork(autoacquire=True, networkid=n))
+            auto_acquire = True
+            network_id = n
+            if ":" in n:
+                network_id = n.split(":")[0]
+                mode = n.split(":")[-1]
+                if mode == "noauto":
+                    auto_acquire = False
+                elif mode == "auto":
+                    auto_acquire = True
+                else:
+                    self._module.fail_json(
+                        msg="network acquisition mode not supported: %s" % mode)
+
+            networks.append(models.V1MachineAllocationNetwork(autoacquire=auto_acquire, networkid=network_id))
 
         self._tags.append(ANSIBLE_CI_MANAGED_TAG)
 

--- a/library/metal_network.py
+++ b/library/metal_network.py
@@ -4,6 +4,7 @@
 try:
     from metal_python.api import NetworkApi
     from metal_python import models
+    from metal_python import rest
 
     METAL_PYTHON_AVAILABLE = True
 except ImportError:
@@ -147,7 +148,11 @@ class Instance(object):
             return
 
         r = models.V1NetworkFindRequest(name=self._name, partitionid=self._partition, projectid=self._project)
-        networks = self._api_client.find_networks(r)
+        try:
+            networks = self._api_client.find_networks(r)
+        except rest.ApiException as e:
+            self._module.fail_json(msg="request to metal-api failed", error=str(e))
+            return
 
         if len(networks) > 1:
             self._module.fail_json(

--- a/library/metal_project.py
+++ b/library/metal_project.py
@@ -4,6 +4,7 @@
 try:
     from metal_python.api import ProjectApi
     from metal_python import models
+    from metal_python import rest
 
     METAL_PYTHON_AVAILABLE = True
 except ImportError:
@@ -127,7 +128,11 @@ class Instance(object):
 
     def _find(self):
         r = models.V1ProjectFindRequest(name=self._name)
-        projects = self._api_client.find_projects(r)
+        try:
+            projects = self._api_client.find_projects(r)
+        except rest.ApiException as e:
+            self._module.fail_json(msg="request to metal-api failed", error=str(e))
+            return
 
         if projects is None:
             return

--- a/library/metal_project.py
+++ b/library/metal_project.py
@@ -1,0 +1,194 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+try:
+    from metal_python.api import ProjectApi
+    from metal_python import models
+
+    METAL_PYTHON_AVAILABLE = True
+except ImportError:
+    METAL_PYTHON_AVAILABLE = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.metal import AUTH_SPEC, ANSIBLE_CI_MANAGED_LABEL, ANSIBLE_CI_MANAGED_KEY, \
+    ANSIBLE_CI_MANAGED_VALUE, init_driver_for_module
+
+ANSIBLE_METADATA = {
+    'metadata_version': '0.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: metal_project
+
+short_description: A module to manage metal project entities
+
+version_added: "2.8"
+
+description:
+    - Manages project entities in the metal-api.
+    - Requires metal_python to be installed.
+    - Cannot update entities.
+
+options:
+    name:
+        description:
+            - >-
+              The name of the project, which must be globally unique.
+              Otherwise, the module cannot figure out if the project was already created or not.
+        required: true
+    description:
+        description:
+            - The description of the project.
+        required: false
+    tenant:
+        tenant:
+            - The tenant of the project.
+        required: false
+    labels:
+        description:
+            - The labels of the project.
+        required: false
+    state:
+        description:
+          - Assert the state of the project.
+          - >-
+            Use C(present) to create or update a project and C(absent) to
+            delete it.
+        default: present
+        choices:
+          - absent
+          - present
+
+author:
+    - metal-stack
+'''
+
+EXAMPLES = '''
+- name: allocate a project
+  metal_project:
+    name: my-project
+    description: "my project"
+    labels:
+      - my-project-label
+
+- name: free a project
+  metal_project:
+    name: my-project
+    state: absent
+'''
+
+RETURN = '''
+id:
+    description:
+        - project id
+    returned: always
+    type: str
+    sample: 3e977e81-6ab5-4f28-b608-e7e94d62efb7
+'''
+
+
+class Instance(object):
+    def __init__(self, module):
+        if not METAL_PYTHON_AVAILABLE:
+            raise RuntimeError("metal_python must be installed")
+
+        self._module = module
+        self.changed = False
+        self._project = None
+        self.id = None
+        self._name = module.params['name']
+        self._description = module.params.get('description')
+        self._tenant = module.params.get('tenant')
+        self._labels = module.params.get('labels')
+        self._state = module.params.get('state')
+        self._driver = init_driver_for_module(self._module)
+        self._api_client = ProjectApi(api_client=self._driver.client)
+
+    def run(self):
+        if self._module.check_mode:
+            return
+
+        self._find()
+
+        if self._state == "present":
+            if self._project:
+                return
+
+            self._project_allocate()
+            self.changed = True
+
+        elif self._state == "absent":
+            if self._project:
+                self._project_free()
+                self.changed = True
+
+    def _find(self):
+        r = models.V1ProjectFindRequest(name=self._name)
+        projects = self._api_client.find_projects(r)
+
+        if projects is None:
+            return
+
+        if len(projects) > 1:
+            self._module.fail_json(
+                msg="project name is not globally unique, which is required when "
+                    "using this module", name=self._name)
+        elif len(projects) == 1:
+            self._project = projects[0]
+            self.id = self._project.meta.id
+
+    def _project_allocate(self):
+        labels = ANSIBLE_CI_MANAGED_LABEL
+
+        r = models.V1ProjectCreateRequest(description=self._description,
+                                          meta=dict(
+                                              annotations=labels,
+                                              labels=self._labels,
+                                          ),
+                                          name=self._name,
+                                          tenant_id=self._tenant)
+
+        self._project = self._api_client.create_project(r)
+        self.id = self._project.meta.id
+
+    def _project_free(self):
+        if self._project.meta.annotations.get(ANSIBLE_CI_MANAGED_KEY) != ANSIBLE_CI_MANAGED_VALUE:
+            self._module.fail_json(msg="entity does not have label attached: %s" % ANSIBLE_CI_MANAGED_LABEL,
+                                   name=self._name)
+
+        self._project = self._api_client.delete_project(self.id)
+        self.id = self._project.meta.id
+
+
+def main():
+    argument_spec = AUTH_SPEC.copy()
+    argument_spec.update(dict(
+        id=dict(type='str', required=False),
+        name=dict(type='str', required=True),
+        tenant=dict(type='str', required=False),
+        description=dict(type='str', required=False),
+        labels=dict(type='list', required=False),
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+    ))
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    instance = Instance(module)
+
+    instance.run()
+
+    result = dict(
+        changed=instance.changed,
+        id=instance.id,
+    )
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/module_utils/metal.py
+++ b/module_utils/metal.py
@@ -10,6 +10,7 @@ except ImportError:
 AUTH_SPEC = dict(
     api_url=dict(type='str', required=False),
     api_hmac=dict(type='str', required=False, no_log=True),
+    api_hmac_user=dict(type='str', required=False, default='metal-edit'),
     api_token=dict(type='str', required=False, no_log=True),
 )
 ANSIBLE_CI_MANAGED_KEY = "ci.metal-stack.io/manager"
@@ -25,9 +26,10 @@ def init_driver_for_module(module):
     url = module.params.get("api_url", os.environ.get("METALCTL_URL"))
     hmac = module.params.get("api_hmac", os.environ.get("METALCTL_HMAC"))
     token = module.params.get("api_token", os.environ.get("METALCTL_APITOKEN"))
+    hmac_user = module.params.get("api_hmac_user")
 
-    return init_driver(url, hmac, token)
+    return init_driver(url, hmac, token, hmac_user)
 
 
-def init_driver(url, hmac, token):
-    return Driver(url, token, hmac)
+def init_driver(url, hmac, token, hmac_user):
+    return Driver(url, token, hmac, hmac_user=hmac_user)

--- a/module_utils/metal.py
+++ b/module_utils/metal.py
@@ -10,7 +10,7 @@ except ImportError:
 AUTH_SPEC = dict(
     api_url=dict(type='str', required=False),
     api_hmac=dict(type='str', required=False, no_log=True),
-    api_hmac_user=dict(type='str', required=False, default='metal-edit'),
+    api_hmac_user=dict(type='str', required=False, default='Metal-Edit'),
     api_token=dict(type='str', required=False, no_log=True),
 )
 ANSIBLE_CI_MANAGED_KEY = "ci.metal-stack.io/manager"

--- a/test/metal_project_test.py
+++ b/test/metal_project_test.py
@@ -1,0 +1,273 @@
+import sys
+from mock import patch
+from test import (
+    MetalModules,
+    AnsibleFailJson,
+    AnsibleExitJson,
+    set_module_args,
+    MODULES_PATH,
+)
+from metal_python import models
+
+sys.path.insert(0, MODULES_PATH)
+
+
+class TestMetalProjectModule(MetalModules):
+    def setUp(self):
+        self.defaultSetUpTasks()
+
+        import metal_project
+        self.module = metal_project
+
+    @patch("metal_python.api.project_api.ProjectApi.find_projects",
+           side_effect=[
+               []
+           ])
+    @patch("metal_python.api.project_api.ProjectApi.create_project",
+           side_effect=[
+               models.V1ProjectResponse(
+                   description="desc",
+                   meta=models.V1Meta(
+                       id="656c784a-77f9-4d8c-9382-4d42d1b14eb0",
+                       annotations={
+                           "ci.metal-stack.io/manager": "ansible",
+                       },
+                       labels=[
+                           "a-label",
+                       ],
+                   ),
+                   name="project-a",
+                   tenant_id="tt")
+           ])
+    def test_project_present(self, create_mock, find_mock):
+        set_module_args(
+            dict(
+                api_url="http://somewhere",
+                api_hmac="hmac",
+                name="project-a",
+                tenant="tt",
+                description="desc",
+                labels=["a-label"],
+            )
+        )
+
+        with self.assertRaises(AnsibleExitJson) as result:
+            self.module.main()
+
+        find_mock.assert_called()
+        find_mock.assert_called_with(
+            models.V1ProjectFindRequest(
+                name="project-a"
+            )
+        )
+        create_mock.assert_called()
+        create_mock.assert_called_with(
+            models.V1ProjectCreateRequest(
+                description="desc",
+                name="project-a",
+                tenant_id="tt",
+                meta=models.V1Meta(
+                    annotations={
+                        "ci.metal-stack.io/manager": "ansible",
+                    },
+                    labels=[
+                        "a-label",
+                    ],
+                ),
+            )
+        )
+
+        expected = dict(
+            id="656c784a-77f9-4d8c-9382-4d42d1b14eb0",
+            changed=True,
+        )
+        self.assertDictEqual(result.exception.module_results, expected)
+
+    @patch("metal_python.api.project_api.ProjectApi.find_projects",
+           side_effect=[
+               [
+                   models.V1ProjectResponse(
+                       description="desc",
+                       meta=models.V1Meta(
+                           id="656c784a-77f9-4d8c-9382-4d42d1b14eb0",
+                           annotations={
+                               "ci.metal-stack.io/manager": "ansible",
+                           },
+                           labels=[
+                               "a-label",
+                           ],
+                       ),
+                       name="project-a",
+                       tenant_id="tt",
+                   )
+               ]
+           ])
+    def test_project_present_already_exists(self, find_mock):
+        set_module_args(
+            dict(
+                api_url="http://somewhere",
+                api_hmac="hmac",
+                name="project-a",
+                tenant="tt",
+                description="desc",
+                labels=["a-label"],
+            )
+        )
+
+        with self.assertRaises(AnsibleExitJson) as result:
+            self.module.main()
+
+        find_mock.assert_called()
+        find_mock.assert_called_with(
+            models.V1ProjectFindRequest(
+                name="project-a"
+            )
+        )
+
+        expected = dict(
+            id="656c784a-77f9-4d8c-9382-4d42d1b14eb0",
+            changed=False,
+        )
+        self.assertDictEqual(result.exception.module_results, expected)
+
+    @patch("metal_python.api.project_api.ProjectApi.find_projects",
+           side_effect=[
+               [
+                   models.V1ProjectResponse(
+                       description="desc",
+                       meta=models.V1Meta(
+                           id="656c784a-77f9-4d8c-9382-4d42d1b14eb0",
+                           annotations={
+                               "ci.metal-stack.io/manager": "ansible",
+                           },
+                           labels=[
+                               "a-label",
+                           ],
+                       ),
+                       name="project-a",
+                       tenant_id="tt",
+                   )
+               ]
+           ])
+    @patch("metal_python.api.project_api.ProjectApi.update_project",
+           side_effect=[
+               models.V1ProjectResponse(
+                   description="desc",
+                   meta=models.V1Meta(
+                       id="656c784a-77f9-4d8c-9382-4d42d1b14eb0",
+                       annotations={
+                           "ci.metal-stack.io/manager": "ansible",
+                       },
+                       labels=[
+                           "a-label",
+                       ],
+                   ),
+                   name="project-a",
+                   tenant_id="tt")
+           ])
+    def test_project_present_update(self, update_mock, find_mock):
+        set_module_args(
+            dict(
+                api_url="http://somewhere",
+                api_hmac="hmac",
+                name="project-a",
+                tenant="new-tenant",
+                description="desc",
+                labels=["a-label", "second-label"],
+            )
+        )
+
+        with self.assertRaises(AnsibleExitJson) as result:
+            self.module.main()
+
+        find_mock.assert_called()
+        find_mock.assert_called_with(
+            models.V1ProjectFindRequest(
+                name="project-a"
+            )
+        )
+        update_mock.assert_called()
+        update_mock.assert_called_with(
+            models.V1ProjectUpdateRequest(
+                tenant_id="new-tenant",
+                meta=models.V1Meta(
+                    id="656c784a-77f9-4d8c-9382-4d42d1b14eb0",
+                    labels=[
+                        "a-label",
+                        "second-label",
+                    ],
+                ),
+            )
+        )
+
+        expected = dict(
+            id="656c784a-77f9-4d8c-9382-4d42d1b14eb0",
+            changed=True,
+        )
+        self.assertDictEqual(result.exception.module_results, expected)
+
+    @patch("metal_python.api.project_api.ProjectApi.find_projects",
+           side_effect=[
+               [
+                   models.V1ProjectResponse(
+                       description="desc",
+                       meta=models.V1Meta(
+                           id="656c784a-77f9-4d8c-9382-4d42d1b14eb0",
+                           annotations={
+                               "ci.metal-stack.io/manager": "ansible",
+                           },
+                           labels=[
+                               "a-label",
+                           ],
+                       ),
+                       name="project-a",
+                       tenant_id="tt",
+                   )
+               ]
+           ])
+    @patch("metal_python.api.project_api.ProjectApi.delete_project",
+           side_effect=[
+               models.V1ProjectResponse(
+                   description="desc",
+                   meta=models.V1Meta(
+                       id="656c784a-77f9-4d8c-9382-4d42d1b14eb0",
+                       annotations={
+                           "ci.metal-stack.io/manager": "ansible",
+                       },
+                       labels=[
+                           "a-label",
+                       ],
+                   ),
+                   name="project-a",
+                   tenant_id="tt")
+           ])
+    def test_project_absent(self, delete_mock, find_mock):
+        set_module_args(
+            dict(
+                api_url="http://somewhere",
+                api_hmac="hmac",
+                name="project-a",
+                tenant="tt",
+                description="desc",
+                labels=["a-label"],
+                state="absent",
+            )
+        )
+
+        with self.assertRaises(AnsibleExitJson) as result:
+            self.module.main()
+
+        find_mock.assert_called()
+        find_mock.assert_called_with(
+            models.V1ProjectFindRequest(
+                name="project-a"
+            )
+        )
+        delete_mock.assert_called()
+        delete_mock.assert_called_with("656c784a-77f9-4d8c-9382-4d42d1b14eb0")
+
+        expected = dict(
+            id="656c784a-77f9-4d8c-9382-4d42d1b14eb0",
+            changed=True,
+        )
+        self.assertDictEqual(result.exception.module_results, expected)


### PR DESCRIPTION
Quite some nice changes on the modules:

- New module `metal_project`
- `metal_ip` and `metal_network` can now update properties
- Improved error messages when calls to metal-api are failing
- IP acquisition mode can now be specified for machine creation
- Usage of `Metal-Edit` user by default instead of `Metal-Admin` for HMAC auth
