### PR TITLE
More updates on V2 modules

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,3 +1,3 @@
 ARG METAL_DEPLOYMENT_BASE_VERSION=latest
 FROM ghcr.io/metal-stack/metal-deployment-base:${METAL_DEPLOYMENT_BASE_VERSION}
-RUN pip install metal-stack-api bufbuild-protovalidate-protocolbuffers-python --extra-index-url  https://buf.build/gen/python
+RUN pip install metal-stack-api==0.0.48 bufbuild-protovalidate-protocolbuffers-python --extra-index-url  https://buf.build/gen/python

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,3 +1,3 @@
 ARG METAL_DEPLOYMENT_BASE_VERSION=latest
 FROM ghcr.io/metal-stack/metal-deployment-base:${METAL_DEPLOYMENT_BASE_VERSION}
-RUN pip install metal-stack-api==0.0.48 bufbuild-protovalidate-protocolbuffers-python --extra-index-url  https://buf.build/gen/python
+RUN pip install metal-stack-api==0.0.49 bufbuild-protovalidate-protocolbuffers-python --extra-index-url  https://buf.build/gen/python

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ run-v2-test-example:
 		-w /metal-modules \
 		--network host \
 		metal-ansible-modules /bin/bash -ce \
-		  "pip freeze; ansible-playbook example_v2.yaml -vvv"
+		  "ansible-playbook example_v2.yaml -vvv"

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ run-v2-test-example:
 		-w /metal-modules \
 		--network host \
 		metal-ansible-modules /bin/bash -ce \
-		  "ansible-playbook example_v2.yaml -vvv"
+		  "pip freeze; ansible-playbook example_v2.yaml -vvv"

--- a/example_v2.yaml
+++ b/example_v2.yaml
@@ -37,7 +37,7 @@
       metal_v2_project:
         name: test
         description: test project
-        tenant: CiQwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDESBWxvY2Fs@oidc
+        tenant: "{{ tenant.id }}"
         avatar_url: http://test
         # state: absent
       register: project

--- a/library/metal_v2_admin_tenant.py
+++ b/library/metal_v2_admin_tenant.py
@@ -10,7 +10,8 @@ try:
     from connectrpc.errors import ConnectError
     from google.protobuf.json_format import MessageToDict
 
-    from metalstack.api.v2 import common_pb2, project_pb2
+    from metalstack.api.v2 import common_pb2, tenant_pb2
+    from metalstack.admin.v2 import tenant_pb2 as admin_tenant_pb2
     from metalstack.client import client as apiclient
 
     METAL_STACK_API_AVAILABLE = True
@@ -26,44 +27,44 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = '''
 ---
-module: metal_v2_project
+module: metal_v2_admin_tenant
 
-short_description: A module to manage metal project entities.
+short_description: A module to manage metal tenant entities.
 
 version_added: "2.18"
 
 description:
-    - Manages project entities in the metal-apiserver.
+    - Manages tenant entities in the metal-apiserver.
     - Requires metal-stack-api to be installed.
 
 options:
     name:
         description:
             - >-
-              The name of the project, which must be unique in the tenant.
-              Otherwise, the module cannot figure out if the project was already created or not.
+              The name of the tenant, which must be globally unique.
+              Otherwise, the module cannot figure out if the tenant was already created or not.
         required: true
     description:
         description:
-            - The description of the project.
+            - The description of the tenant.
         required: true
     avatar_url:
         description:
-            - The avatar url of the project.
+            - The avatar url of the tenant.
         required: false
-    tenant:
-        tenant:
-            - The tenant of the project.
+    email:
+        description:
+            - The email of the tenant.
         required: false
     labels:
         description:
-            - The labels of the project.
+            - The labels of the tenant.
         required: false
     state:
         description:
-          - Assert the state of the project.
+          - Assert the state of the tenant.
           - >-
-            Use C(present) to create or update a project and C(absent) to
+            Use C(present) to create or update a tenant and C(absent) to
             delete it.
         default: present
         choices:
@@ -75,42 +76,38 @@ author:
 '''
 
 EXAMPLES = '''
-- name: create a project
-  metal_v2_project:
-    name: my-project
-    description: test project
-    tenant: user@oidc
+- name: create a tenant
+  metal_v2_admin_tenant:
+    name: my-tenant
+    description: test tenant
     avatar_url: http://test
+    email: test@test.com
 
-- name: delete a project
-  metal_v2_project:
-    name: my-project
+- name: delete a tenant
+  metal_v2_admin_tenant:
+    name: my-tenant
     state: absent
 '''
 
 RETURN = '''
 id:
     description:
-        - project id
+        - tenant id
     returned: ifexisted
     type: str
-    sample: 3e977e81-6ab5-4f28-b608-e7e94d62efb7
-project:
-    description:
-        - project response
-    returned: ifexisted
-    type: dict
-    sample:
-        avatarUrl: http://test
-        description: test project
-        meta:
-            createdAt: '2025-01-01T12:00:00.00000000Z'
+    sample: b5bc5d9f-3ade-4eac-bb8c-eb309045151f
+tenant:
+    avatarUrl: http://test
+    createdBy: user@oidc
+    description: test tenant
+    email: admin@metal-stack.io
+    login: b5bc5d9f-3ade-4eac-bb8c-eb309045151f
+    meta:
+        createdAt: '2025-01-01T12:00:00.00000000Z'
+        labels:
             labels:
-                labels:
-                    ci.metal-stack.io/manager: ansible
-        name: test
-        tenant: user@oidc
-        uuid: 3e977e81-6ab5-4f28-b608-e7e94d62efb7
+                ci.metal-stack.io/manager: ansible
+    name: test
 '''
 
 
@@ -121,12 +118,12 @@ class Instance(object):
 
         self._module = module
         self.changed = False
-        self._project: project_pb2.Project = None
-        self._uuid = None
+        self._tenant: tenant_pb2.Tenant = None
+        self._login = None
         self._name = module.params['name']
         self._description = module.params.get('description')
         self._avatar_url = module.params.get('avatar_url')
-        self._tenant = module.params.get('tenant')
+        self._email = module.params.get('email')
         self._labels = module.params.get('labels')
         self._state = module.params.get('state')
         client = init_client_for_module(module)
@@ -140,7 +137,7 @@ class Instance(object):
         self._find()
 
         if self._state == "present":
-            if self._project:
+            if self._tenant:
                 self._update()
                 return
 
@@ -148,69 +145,72 @@ class Instance(object):
             self.changed = True
 
         elif self._state == "absent":
-            if self._project:
+            if self._tenant:
                 self._delete()
                 self.changed = True
 
     def _find(self):
-        r = project_pb2.ProjectServiceListRequest(
+        r = admin_tenant_pb2.TenantServiceListRequest(
             name=self._name,
-            tenant=self._tenant,
         )
 
         try:
-            resp = self._client.apiv2().project().list(request=r, headers=self._headers)
+            resp = self._client.adminv2().tenant().list(request=r, headers=self._headers)
         except ConnectError as e:
             self._module.fail_json(
                 msg="request to metal-apiserver failed", error=str(e))
             return
 
-        projects = resp.projects
+        tenants = resp.tenants
 
-        if projects is None:
+        if tenants is None:
             return
 
-        if len(projects) > 1:
+        if len(tenants) > 1:
             self._module.fail_json(
-                msg="project name is not unique within the tenant, which is required when "
+                msg="tenant name is not unique, which is required when "
                     "using this module", name=self._name)
-        elif len(projects) == 1:
-            self._project = projects[0]
-            self._uuid = self._project.uuid
+        elif len(tenants) == 1:
+            self._tenant = tenants[0]
+            self._login = self._tenant.login
 
     def _update(self):
-        r = project_pb2.ProjectServiceUpdateRequest(
-            project=self._uuid,
+        r = tenant_pb2.TenantServiceUpdateRequest(
+            login=self._login,
             update_meta=common_pb2.UpdateMeta(
                 locking_strategy=common_pb2.OPTIMISTIC_LOCKING_STRATEGY_CLIENT,
                 updated_at=datetime.now(),
             ),
         )
 
-        if not self._project.meta.labels.labels.get(V2_ANSIBLE_CI_MANAGED_KEY, "") == V2_ANSIBLE_CI_MANAGED_VALUE:
+        if not self._tenant.meta.labels.labels.get(V2_ANSIBLE_CI_MANAGED_KEY, "") == V2_ANSIBLE_CI_MANAGED_VALUE:
             self._module.fail_json(
                 msg=f"refusing to update because label is not present on entity: {V2_ANSIBLE_CI_MANAGED_KEY}={V2_ANSIBLE_CI_MANAGED_VALUE}")
             return
 
-        if self._description and self._project.description != self._description:
+        if self._description and self._tenant.description != self._description:
             self.changed = True
             r.description = self._description
 
-        if self._avatar_url and self._project.avatar_url != self._avatar_url:
+        if self._avatar_url and self._tenant.avatar_url != self._avatar_url:
             self.changed = True
             r.avatar_url = self._avatar_url
+
+        if self._email and self._tenant.email != self._email:
+            self.changed = True
+            r.email = self._email
 
         if self._labels:
             self._labels[V2_ANSIBLE_CI_MANAGED_KEY] = V2_ANSIBLE_CI_MANAGED_VALUE
 
-            if self._project.meta.labels != self._labels:
+            if self._tenant.meta.labels != self._labels:
                 self.changed = True
                 r.labels = self._labels
 
         if self.changed:
             try:
-                resp = self._client.apiv2().project().update(request=r, headers=self._headers)
-                self._project = resp.project
+                resp = self._client.apiv2().tenant().update(request=r, headers=self._headers)
+                self._tenant = resp.tenant
             except ConnectError as e:
                 self._module.fail_json(
                     msg="request to metal-apiserver failed", error=str(e))
@@ -220,8 +220,7 @@ class Instance(object):
             V2_ANSIBLE_CI_MANAGED_KEY: V2_ANSIBLE_CI_MANAGED_VALUE,
         }
 
-        r = project_pb2.ProjectServiceCreateRequest(
-            login=self._tenant,
+        r = admin_tenant_pb2.TenantServiceCreateRequest(
             name=self._name,
             description=self._description,
             labels=common_pb2.Labels(labels=labels),
@@ -229,29 +228,31 @@ class Instance(object):
 
         if self._avatar_url:
             r.avatar_url = self._avatar_url
+        if self._email:
+            r.email = self._email
         if self._labels:
             r.labels = common_pb2.Labels(labels=self._labels | labels)
 
         try:
-            resp = self._client.apiv2().project().create(request=r, headers=self._headers)
-            self._project = resp.project
+            resp = self._client.adminv2().tenant().create(request=r, headers=self._headers)
+            self._tenant = resp.tenant
         except ConnectError as e:
             self._module.fail_json(
                 msg="request to metal-apiserver failed", error=str(e))
 
-        self._uuid = self._project.uuid
+        self._login = self._tenant.login
 
     def _delete(self):
-        if not self._project.meta.labels.labels.get(V2_ANSIBLE_CI_MANAGED_KEY, "") == V2_ANSIBLE_CI_MANAGED_VALUE:
+        if not self._tenant.meta.labels.labels.get(V2_ANSIBLE_CI_MANAGED_KEY, "") == V2_ANSIBLE_CI_MANAGED_VALUE:
             self._module.fail_json(
                 msg=f"refusing to delete because label is not present on entity: {V2_ANSIBLE_CI_MANAGED_KEY}={V2_ANSIBLE_CI_MANAGED_VALUE}")
             return
 
         try:
-            resp = self._client.apiv2().project().delete(project_pb2.ProjectServiceDeleteRequest(
-                project=self._uuid,
-            ), headers=self._headers)
-            self._project = resp.project
+            resp = self._client.apiv2().tenant().delete(tenant_pb2.TenantServiceDeleteRequest(
+                login=self._login,
+            ))
+            self._tenant = resp.tenant
         except ConnectError as e:
             self._module.fail_json(
                 msg="request to metal-apiserver failed", error=str(e))
@@ -261,9 +262,9 @@ def main():
     argument_spec = V2_AUTH_SPEC.copy()
     argument_spec.update(dict(
         name=dict(type='str', required=True),
-        tenant=dict(type='str', required=True),
         description=dict(type='str', required=True),
         avatar_url=dict(type='str', required=False),
+        email=dict(type='str', required=False),
         labels=dict(type='list', required=False),
         state=dict(type='str', choices=[
                    'present', 'absent'], default='present'),
@@ -279,11 +280,11 @@ def main():
 
     result = dict(
         changed=instance.changed,
-        id=instance._uuid,
+        id=instance._login,
     )
 
-    if instance._project:
-        result['project'] = MessageToDict(instance._project)
+    if instance._tenant:
+        result['tenant'] = MessageToDict(instance._tenant)
 
     module.exit_json(**result)
 

--- a/library/metal_v2_admin_token.py
+++ b/library/metal_v2_admin_token.py
@@ -11,6 +11,7 @@ try:
     from google.protobuf.json_format import MessageToDict
 
     from metalstack.api.v2 import common_pb2, token_pb2
+    from metalstack.admin.v2 import token_pb2 as admin_token_pb2
     from metalstack.client import client as apiclient
 
     METAL_STACK_API_AVAILABLE = True
@@ -26,7 +27,7 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = '''
 ---
-module: metal_v2_api_token
+module: metal_v2_admin_token
 
 short_description: A module to manage api token entities.
 
@@ -41,6 +42,10 @@ options:
         description:
             - The description of the token, which must be unique for the user who creates the api token.
               Otherwise, the module cannot figure out if the token was already created or not.
+        required: true
+    user:
+        description:
+            - The user to whom the created token will belong.
         required: true
     admin_role:
         description:
@@ -79,15 +84,18 @@ author:
 
 EXAMPLES = '''
 - name: create a token
-  metal_v2_api_token:
+  metal_v2_admin_token:
+    user: metal-bmc
     description: an infra component token
     permissions:
-    - subject: 3e977e81-6ab5-4f28-b608-e7e94d62efb7
+    - subject: '*'
       methods:
         - /metalstack.infra.v2.BMCService/UpdateBMCInfo
+        - /metalstack.api.v2.TokenService/Refresh
 
 - name: revoke a token
-  metal_v2_api_token:
+  metal_v2_admin_token:
+    user: metal-bmc
     description: an infra component token
     state: absent
 '''
@@ -112,7 +120,8 @@ token:
     permissions:
     -   methods:
         - /metalstack.infra.v2.BMCService/UpdateBMCInfo
-        subject: e0588ffb-8e95-4f51-ba68-721cbf798543
+        - /metalstack.api.v2.TokenService/Refresh
+        subject: '*'
     tokenType: TOKEN_TYPE_API
     user: user@oidc
     uuid: ae6834bd-1ca8-4d22-b38a-8a7c771c06b0
@@ -129,6 +138,7 @@ class Instance(object):
         self._token: token_pb2.Token = None
         self._uuid = None
         self._secret = None
+        self._user = module.params.get('user')
         self._description = module.params.get('description')
         self._expires = parse_delta(module.params.get(
             'expires')) if module.params.get('expires') else None
@@ -161,11 +171,12 @@ class Instance(object):
                 self.changed = True
 
     def _find(self):
-        # TODO: some search filters would be useful in the API?
-        r = token_pb2.TokenServiceListRequest()
+        r = admin_token_pb2.TokenServiceListRequest(
+            user=self._user
+        )
 
         try:
-            resp = self._client.apiv2().token().list(request=r, headers=self._headers)
+            resp = self._client.adminv2().token().list(request=r, headers=self._headers)
         except ConnectError as e:
             self._module.fail_json(
                 msg="request to metal-apiserver failed", error=str(e))
@@ -295,7 +306,10 @@ class Instance(object):
                     role.get("role"))
 
         try:
-            resp = self._client.apiv2().token().create(request=r, headers=self._headers)
+            resp = self._client.adminv2().token().create(request=admin_token_pb2.TokenServiceCreateRequest(
+                user=self._user,
+                token_create_request=r,
+            ), headers=self._headers)
             self._token = resp.token
             self._secret = resp.secret
         except ConnectError as e:
@@ -312,7 +326,8 @@ class Instance(object):
         #     return
 
         try:
-            self._client.apiv2().token().revoke(request=token_pb2.TokenServiceRevokeRequest(
+            self._client.adminv2().token().revoke(request=admin_token_pb2.TokenServiceRevokeRequest(
+                user=self._user,
                 uuid=self._uuid,
             ), headers=self._headers)
         except ConnectError as e:
@@ -323,6 +338,7 @@ class Instance(object):
 def main():
     argument_spec = V2_AUTH_SPEC.copy()
     argument_spec.update(dict(
+        user=dict(type='str', required=True),
         description=dict(type='str', required=True),
         expires=dict(type='str', required=False),
         permissions=dict(type='list', required=False, elements='dict', options=dict(

--- a/library/metal_v2_api_token.py
+++ b/library/metal_v2_api_token.py
@@ -137,7 +137,9 @@ class Instance(object):
         self._admin_role = module.params.get('admin_role')
         self._permissions = module.params.get('permissions')
         self._state = module.params.get('state')
-        self._client: apiclient.Client = init_client_for_module(module)
+        client = init_client_for_module(module)
+        self._client: apiclient.Client = client[0]
+        self._headers: dict = client[1]
 
     def run(self):
         if self._module.check_mode:
@@ -163,7 +165,7 @@ class Instance(object):
         r = token_pb2.TokenServiceListRequest()
 
         try:
-            resp = self._client.apiv2().token().list(request=r)
+            resp = self._client.apiv2().token().list(request=r, headers=self._headers)
         except ConnectError as e:
             self._module.fail_json(
                 msg="request to metal-apiserver failed", error=str(e))
@@ -254,7 +256,7 @@ class Instance(object):
 
         if self.changed:
             try:
-                resp = self._client.apiv2().token().update(r)
+                resp = self._client.apiv2().token().update(request=r, headers=self._headers)
                 self._token = resp.token
             except ConnectError as e:
                 self._module.fail_json(
@@ -293,7 +295,7 @@ class Instance(object):
                     role.get("role"))
 
         try:
-            resp = self._client.apiv2().token().create(r)
+            resp = self._client.apiv2().token().create(request=r, headers=self._headers)
             self._token = resp.token
             self._secret = resp.secret
         except ConnectError as e:
@@ -310,9 +312,9 @@ class Instance(object):
         #     return
 
         try:
-            self._client.apiv2().token().revoke(token_pb2.TokenServiceRevokeRequest(
+            self._client.apiv2().token().revoke(request=token_pb2.TokenServiceRevokeRequest(
                 uuid=self._uuid,
-            ))
+            ), headers=self._headers)
         except ConnectError as e:
             self._module.fail_json(
                 msg="request to metal-apiserver failed", error=str(e))

--- a/library/metal_v2_project.py
+++ b/library/metal_v2_project.py
@@ -129,7 +129,9 @@ class Instance(object):
         self._tenant = module.params.get('tenant')
         self._labels = module.params.get('labels')
         self._state = module.params.get('state')
-        self._client: apiclient.Client = init_client_for_module(module)
+        client = init_client_for_module(module)
+        self._client: apiclient.Client = client[0]
+        self._headers: dict = client[1]
 
     def run(self):
         if self._module.check_mode:
@@ -157,7 +159,7 @@ class Instance(object):
         )
 
         try:
-            resp = self._client.apiv2().project().list(request=r)
+            resp = self._client.apiv2().project().list(request=r, headers=self._headers)
         except ConnectError as e:
             self._module.fail_json(
                 msg="request to metal-apiserver failed", error=str(e))
@@ -207,7 +209,7 @@ class Instance(object):
 
         if self.changed:
             try:
-                resp = self._client.apiv2().project().update(r)
+                resp = self._client.apiv2().project().update(request=r, headers=self._headers)
                 self._project = resp.project
             except ConnectError as e:
                 self._module.fail_json(
@@ -231,7 +233,7 @@ class Instance(object):
             r.labels = common_pb2.Labels(labels=self._labels | labels)
 
         try:
-            resp = self._client.apiv2().project().create(r)
+            resp = self._client.apiv2().project().create(request=r, headers=self._headers)
             self._project = resp.project
         except ConnectError as e:
             self._module.fail_json(
@@ -248,7 +250,7 @@ class Instance(object):
         try:
             resp = self._client.apiv2().project().delete(project_pb2.ProjectServiceDeleteRequest(
                 project=self._uuid,
-            ))
+            ), headers=self._headers)
             self._project = resp.project
         except ConnectError as e:
             self._module.fail_json(

--- a/library/metal_v2_tenant.py
+++ b/library/metal_v2_tenant.py
@@ -82,7 +82,7 @@ EXAMPLES = '''
     avatar_url: http://test
     email: test@test.com
 
-- name: free a tenant
+- name: delete a tenant
   metal_v2_tenant:
     name: my-tenant
     state: absent

--- a/library/metal_v2_tenant.py
+++ b/library/metal_v2_tenant.py
@@ -125,7 +125,9 @@ class Instance(object):
         self._email = module.params.get('email')
         self._labels = module.params.get('labels')
         self._state = module.params.get('state')
-        self._client: apiclient.Client = init_client_for_module(module)
+        client = init_client_for_module(module)
+        self._client: apiclient.Client = client[0]
+        self._headers: dict = client[1]
 
     def run(self):
         if self._module.check_mode:
@@ -152,7 +154,7 @@ class Instance(object):
         )
 
         try:
-            resp = self._client.apiv2().tenant().list(request=r)
+            resp = self._client.apiv2().tenant().list(request=r, headers=self._headers)
         except ConnectError as e:
             self._module.fail_json(
                 msg="request to metal-apiserver failed", error=str(e))
@@ -206,7 +208,7 @@ class Instance(object):
 
         if self.changed:
             try:
-                resp = self._client.apiv2().tenant().update(r)
+                resp = self._client.apiv2().tenant().update(request=r, headers=self._headers)
                 self._tenant = resp.tenant
             except ConnectError as e:
                 self._module.fail_json(
@@ -231,7 +233,7 @@ class Instance(object):
             r.labels = common_pb2.Labels(labels=self._labels | labels)
 
         try:
-            resp = self._client.apiv2().tenant().create(r)
+            resp = self._client.apiv2().tenant().create(request=r, headers=self._headers)
             self._tenant = resp.tenant
         except ConnectError as e:
             self._module.fail_json(

--- a/module_utils/metal_v2.py
+++ b/module_utils/metal_v2.py
@@ -19,7 +19,7 @@ V2_ANSIBLE_CI_MANAGED_KEY = "ci.metal-stack.io/manager"
 V2_ANSIBLE_CI_MANAGED_VALUE = "ansible"
 
 
-def init_client_for_module(module) -> apiclient.Client:
+def init_client_for_module(module):
     if not METAL_STACK_API_AVAILABLE:
         module.fail_json(msg="metal-stack-api must be installed")
 
@@ -39,13 +39,11 @@ def init_client_for_module(module) -> apiclient.Client:
 
     args = dict(
         baseurl=url,
-        token=token
     )
-
     if timeout:
         args["timeout"] = timeout
 
-    return apiclient.Client(**args)
+    return apiclient.Client(**args), dict(Authorization="Bearer " + token)
 
 
 # taken from this gist: https://gist.github.com/santiagobasulto/698f0ff660968200f873a2f9d1c4113c


### PR DESCRIPTION
## Description

This can be used to deploy metal-image-cache-sync onto a leaf switch.

- Adds `metal_v2_admin_tenant` module
- Adds `metal_v2_admin_token`
- Adapt to latest API python client

Needs more tests and also the labels for tokens would be really nice. We should take care of this in another iteration.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
