### PR TITLE
Act on latest created resource when using identifier label.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,15 @@ The v2 modules require the [metal-stack-api](https://pypi.org/project/metal-stac
 
 ## V2 Modules
 
-| Module Name                                         | Description                            | Requirements    |
-| --------------------------------------------------- | -------------------------------------- | --------------- |
-| [metal_v2_project](library/metal_v2_project.py)     | Manages metal-stack project entities   | metal-stack-api |
-| [metal_v2_tenant](library/metal_v2_tenant.py)       | Manages metal-stack tenant entities    | metal-stack-api |
-| [metal_v2_api_token](library/metal_v2_api_token.py) | Manages metal-stack api token entities | metal-stack-api |
+| Module Name                                                     | Description                            | Requirements    |
+| --------------------------------------------------------------- | -------------------------------------- | --------------- |
+| [metal_v2_admin_api_token](library/metal_v2_admin_api_token.py) | Manages metal-stack api token entities | metal-stack-api |
+| [metal_v2_admin_project](library/metal_v2_admin_project.py)     | Manages metal-stack project entities   | metal-stack-api |
+| [metal_v2_admin_tenant](library/metal_v2_admin_tenant.py)       | Manages metal-stack tenant entities    | metal-stack-api |
+| [metal_v2_api_token](library/metal_v2_api_token.py)             | Manages metal-stack api token entities | metal-stack-api |
+| [metal_v2_project](library/metal_v2_project.py)                 | Manages metal-stack project entities   | metal-stack-api |
+| [metal_v2_tenant](library/metal_v2_tenant.py)                   | Manages metal-stack tenant entities    | metal-stack-api |
+
 
 ## Dynamic Inventories
 

--- a/example_v2.yaml
+++ b/example_v2.yaml
@@ -55,6 +55,7 @@
       metal_v2_admin_token:
         user: metal-stack
         identifier: metal-bmc
+        use_latest_identifier: true
         description: "for metal-bmc"
         expires: 1d
         permissions:

--- a/example_v2.yaml
+++ b/example_v2.yaml
@@ -14,19 +14,19 @@
         name: test
         description: test tenant
         avatar_url: http://test
-        email: test@test.com
+        email: test@test2.com
         # state: absent
       register: tenant
 
-    - name: Create tenant
-      metal_v2_tenant:
-        identifier: test2
-        name: test2
-        description: test tenant2
-        avatar_url: http://test2
-        email: test@test.com2
-        labels:
-          a: b
+    # - name: Create tenant
+    #   metal_v2_tenant:
+    #     identifier: test
+    #     name: test2
+    #     description: test tenant2
+    #     avatar_url: http://test2
+    #     email: test@test.com2
+    #     labels:
+    #       a: b
         # state: absent
 
     - name: Create project

--- a/example_v2.yaml
+++ b/example_v2.yaml
@@ -27,10 +27,10 @@
     #     email: test@test.com2
     #     labels:
     #       a: b
-        # state: absent
+    #     state: absent
 
     - name: Create project
-      metal_v2_project:
+      metal_v2_admin_project:
         identifier: test
         name: test2
         description: test project2

--- a/library/metal_v2_admin_project.py
+++ b/library/metal_v2_admin_project.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from datetime import datetime
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.metal_v2 import V2_AUTH_SPEC, V2_ANSIBLE_CI_MANAGED_KEY, V2_ANSIBLE_CI_MANAGED_VALUE, V2_ANSIBLE_CI_IDENTIFIER_KEY, init_client_for_module, get_latest_resource
 
@@ -10,8 +9,7 @@ try:
     from connectrpc.errors import ConnectError
     from google.protobuf.json_format import MessageToDict
 
-    from metalstack.api.v2 import common_pb2, tenant_pb2
-    from metalstack.admin.v2 import tenant_pb2 as admin_tenant_pb2
+    from metalstack.api.v2 import common_pb2, project_pb2
     from metalstack.client import client as apiclient
 
     METAL_STACK_API_AVAILABLE = True
@@ -27,14 +25,14 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = '''
 ---
-module: metal_v2_admin_tenant
+module: metal_v2_admin_project
 
-short_description: A module to manage metal tenant entities.
+short_description: A module to manage metal project entities.
 
 version_added: "2.18"
 
 description:
-    - Manages tenant entities in the metal-apiserver.
+    - Manages project entities in the metal-apiserver.
     - Requires metal-stack-api to be installed.
 
 options:
@@ -52,30 +50,29 @@ options:
         default: false
     name:
         description:
-            - The name of the tenant.
+            - The name of the project.
         required: true
     description:
         description:
-            - The description of the tenant.
+            - The description of the project.
         required: true
     avatar_url:
         description:
-            - The avatar url of the tenant.
+            - The avatar url of the project.
         required: false
-    email:
-        description:
-            - The email of the tenant.
+    tenant:
+        tenant:
+            - The tenant of the project.
         required: false
     labels:
-        description:
-            - The labels of the tenant.
-            - Set to empty dict in order to clean existing.
+        - The labels of the project.
+        - Set to empty dict in order to clean existing.
         required: false
     state:
         description:
-          - Assert the state of the tenant.
+          - Assert the state of the project.
           - >-
-            Use C(present) to create or update a tenant and C(absent) to
+            Use C(present) to create or update a project and C(absent) to
             delete it.
         default: present
         choices:
@@ -87,40 +84,44 @@ author:
 '''
 
 EXAMPLES = '''
-- name: create a tenant
-  metal_v2_admin_tenant:
-    identifier: my-tenant
-    name: my-tenant
-    description: test tenant
+- name: create a project
+  metal_v2_admin_project:
+    identifier: test
+    name: my-project
+    description: test project
+    tenant: user@oidc
     avatar_url: http://test
-    email: test@test.com
 
-- name: delete a tenant
-  metal_v2_admin_tenant:
-    identifier: my-tenant
+- name: delete a project
+  metal_v2_admin_project:
+    identifier: test
     state: absent
 '''
 
 RETURN = '''
 id:
     description:
-        - tenant id
+        - project id
     returned: ifexisted
     type: str
-    sample: b5bc5d9f-3ade-4eac-bb8c-eb309045151f
-tenant:
-    avatarUrl: http://test
-    createdBy: user@oidc
-    description: test tenant
-    email: admin@metal-stack.io
-    login: b5bc5d9f-3ade-4eac-bb8c-eb309045151f
-    meta:
-        createdAt: '2025-01-01T12:00:00.00000000Z'
-        labels:
+    sample: 3e977e81-6ab5-4f28-b608-e7e94d62efb7
+project:
+    description:
+        - project response
+    returned: ifexisted
+    type: dict
+    sample:
+        avatarUrl: http://test
+        description: test project
+        meta:
+            createdAt: '2025-01-01T12:00:00.00000000Z'
             labels:
-                ci.metal-stack.io/id: test
-                ci.metal-stack.io/manager: ansible
-    name: test
+                labels:
+                    ci.metal-stack.io/id: test
+                    ci.metal-stack.io/manager: ansible
+        name: test
+        tenant: user@oidc
+        uuid: 3e977e81-6ab5-4f28-b608-e7e94d62efb7
 '''
 
 
@@ -131,15 +132,15 @@ class Instance(object):
 
         self._module = module
         self.changed = False
-        self._tenant: tenant_pb2.Tenant = None
-        self._login = None
+        self._project: project_pb2.Project = None
+        self._uuid = None
         self._name = module.params['name']
-        self._description = module.params.get('description')
         self._identifier = module.params.get('identifier')
         self._use_latest_identifier = module.params.get(
             'use_latest_identifier')
+        self._description = module.params.get('description')
         self._avatar_url = module.params.get('avatar_url')
-        self._email = module.params.get('email')
+        self._tenant = module.params.get('tenant')
         self._labels = module.params.get('labels')
         self._state = module.params.get('state')
         client = init_client_for_module(module)
@@ -153,7 +154,7 @@ class Instance(object):
         self._find()
 
         if self._state == "present":
-            if self._tenant:
+            if self._project:
                 self._update()
                 return
 
@@ -161,13 +162,13 @@ class Instance(object):
             self.changed = True
 
         elif self._state == "absent":
-            if self._tenant:
+            if self._project:
                 self._delete()
                 self.changed = True
 
     def _find(self):
-        r = admin_tenant_pb2.TenantServiceListRequest(
-            query=tenant_pb2.TenantQuery(
+        r = project_pb2.ProjectServiceListRequest(
+            query=project_pb2.ProjectQuery(
                 labels=common_pb2.Labels(
                     labels={
                         V2_ANSIBLE_CI_IDENTIFIER_KEY: self._identifier,
@@ -178,40 +179,40 @@ class Instance(object):
         )
 
         try:
-            resp = self._client.adminv2().tenant().list(request=r, headers=self._headers)
+            resp = self._client.adminv2().project().list(request=r, headers=self._headers)
         except ConnectError as e:
             self._module.fail_json(
                 msg="request to metal-apiserver failed", error=str(e))
             return
 
-        self._tenant = get_latest_resource(self, resp.tenants)
-        if self._tenant:
-            self._login = self._tenant.login
+        self._project = get_latest_resource(self, resp.projects)
+        if self._project:
+            self._uuid = self._project.uuid
 
     def _update(self):
-        r = tenant_pb2.TenantServiceUpdateRequest(
-            login=self._login,
+        r = project_pb2.ProjectServiceUpdateRequest(
+            project=self._uuid,
             update_meta=common_pb2.UpdateMeta(
                 locking_strategy=common_pb2.OPTIMISTIC_LOCKING_STRATEGY_CLIENT,
-                updated_at=self._tenant.meta.updated_at,
+                updated_at=self._project.meta.updated_at,
             ),
         )
 
-        if self._name and self._tenant.name != self._name:
+        if self._name and self._project.name != self._name:
             self.changed = True
             r.name = self._name
 
-        if self._description and self._tenant.description != self._description:
+        if self._description and self._project.description != self._description:
             self.changed = True
             r.description = self._description
-
-        if self._avatar_url and self._tenant.avatar_url != self._avatar_url:
+        if self._avatar_url and self._project.avatar_url != self._avatar_url:
             self.changed = True
             r.avatar_url = self._avatar_url
 
-        if self._email and self._tenant.email != self._email:
-            self.changed = True
-            r.email = self._email
+        if self._tenant and self._project.tenant != self._tenant:
+            self._module.fail_json(
+                msg=f"project belongs to tenant {self._project.tenant}, it cannot be changed to tenant {self._tenant}")
+            return
 
         if self._labels != None:
             labels = self._labels | {
@@ -219,7 +220,7 @@ class Instance(object):
                 V2_ANSIBLE_CI_MANAGED_KEY: V2_ANSIBLE_CI_MANAGED_VALUE,
             }
 
-            if self._tenant.meta.labels.labels != labels:
+            if self._project.meta.labels.labels != labels:
                 self.changed = True
                 r.labels.CopyFrom(common_pb2.UpdateLabels(
                     replace=common_pb2.Labels(labels=labels)
@@ -227,8 +228,8 @@ class Instance(object):
 
         if self.changed:
             try:
-                resp = self._client.apiv2().tenant().update(request=r, headers=self._headers)
-                self._tenant = resp.tenant
+                resp = self._client.apiv2().project().update(request=r, headers=self._headers)
+                self._project = resp.project
             except ConnectError as e:
                 self._module.fail_json(
                     msg="request to metal-apiserver failed", error=str(e))
@@ -240,7 +241,8 @@ class Instance(object):
             V2_ANSIBLE_CI_MANAGED_KEY: V2_ANSIBLE_CI_MANAGED_VALUE,
         }
 
-        r = admin_tenant_pb2.TenantServiceCreateRequest(
+        r = project_pb2.ProjectServiceCreateRequest(
+            login=self._tenant,
             name=self._name,
             description=self._description,
             labels=common_pb2.Labels(labels=labels),
@@ -248,26 +250,22 @@ class Instance(object):
 
         if self._avatar_url:
             r.avatar_url = self._avatar_url
-        if self._email:
-            r.email = self._email
-        if self._labels:
-            r.labels = common_pb2.Labels(labels=self._labels | labels)
 
         try:
-            resp = self._client.adminv2().tenant().create(request=r, headers=self._headers)
-            self._tenant = resp.tenant
+            resp = self._client.apiv2().project().create(request=r, headers=self._headers)
+            self._project = resp.project
         except ConnectError as e:
             self._module.fail_json(
                 msg="request to metal-apiserver failed", error=str(e))
 
-        self._login = self._tenant.login
+        self._uuid = self._project.uuid
 
     def _delete(self):
         try:
-            resp = self._client.apiv2().tenant().delete(tenant_pb2.TenantServiceDeleteRequest(
-                login=self._login,
+            resp = self._client.apiv2().project().delete(project_pb2.ProjectServiceDeleteRequest(
+                project=self._uuid,
             ), headers=self._headers)
-            self._tenant = resp.tenant
+            self._project = resp.project
         except ConnectError as e:
             self._module.fail_json(
                 msg="request to metal-apiserver failed", error=str(e))
@@ -279,9 +277,9 @@ def main():
         identifier=dict(type='str', required=True),
         use_latest_identifier=dict(type='bool', default=False),
         name=dict(type='str', required=True),
+        tenant=dict(type='str', required=True),
         description=dict(type='str', required=True),
         avatar_url=dict(type='str', required=False),
-        email=dict(type='str', required=False),
         labels=dict(type='dict', required=False),
         state=dict(type='str', choices=[
                    'present', 'absent'], default='present'),
@@ -297,11 +295,11 @@ def main():
 
     result = dict(
         changed=instance.changed,
-        id=instance._login,
+        id=instance._uuid,
     )
 
-    if instance._tenant:
-        result['tenant'] = MessageToDict(instance._tenant)
+    if instance._project:
+        result['project'] = MessageToDict(instance._project)
 
     module.exit_json(**result)
 

--- a/library/metal_v2_admin_tenant.py
+++ b/library/metal_v2_admin_tenant.py
@@ -40,9 +40,10 @@ description:
 options:
     identifier:
         description:
-            - A resource identifier for the created resource which must be unique within the managed resource scope for resources that have auto-generated uuids.
-              Otherwise, the module cannot figure out if the token was already created or not.
+            - A resource identifier for resources that have auto-generated uuids.
               The identifier gets stored in the resource labels.
+              With this, the module can figure out if the resource already exists using the identifier label.
+              If multiple resources with the identifier label are found, the module acts on the latest created resource.
         required: true
     name:
         description:
@@ -63,8 +64,7 @@ options:
     labels:
         description:
             - The labels of the tenant.
-            - >-
-              Set to empty dict in order to clean existing.
+            - Set to empty dict in order to clean existing.
         required: false
     state:
         description:
@@ -84,6 +84,7 @@ author:
 EXAMPLES = '''
 - name: create a tenant
   metal_v2_admin_tenant:
+    identifier: my-tenant
     name: my-tenant
     description: test tenant
     avatar_url: http://test
@@ -91,7 +92,7 @@ EXAMPLES = '''
 
 - name: delete a tenant
   metal_v2_admin_tenant:
-    name: my-tenant
+    identifier: my-tenant
     state: absent
 '''
 
@@ -177,17 +178,21 @@ class Instance(object):
             return
 
         tenants = resp.tenants
-
         if tenants is None:
             return
 
-        if len(tenants) > 1:
-            self._module.fail_json(
-                msg="tenant identifier label is not unique, which is required when "
-                    "using this module", name=self._name)
-        elif len(tenants) == 1:
-            self._tenant = tenants[0]
-            self._login = self._tenant.login
+        latest_created = None
+
+        for tenant in tenants:
+            if latest_created is None:
+                latest_created = tenant
+                continue
+
+            if tenant.meta.created_at.ToDatetime() > latest_created.meta.created_at.ToDatetime():
+                latest_created = tenant
+
+        self._tenant = latest_created
+        self._login = self._tenant.login
 
     def _update(self):
         r = tenant_pb2.TenantServiceUpdateRequest(

--- a/library/metal_v2_admin_token.py
+++ b/library/metal_v2_admin_token.py
@@ -1,9 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from datetime import datetime
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.metal_v2 import V2_AUTH_SPEC, V2_ANSIBLE_CI_MANAGED_KEY, V2_ANSIBLE_CI_MANAGED_VALUE, V2_ANSIBLE_CI_IDENTIFIER_KEY, init_client_for_module, parse_delta
+from ansible.module_utils.metal_v2 import V2_AUTH_SPEC, V2_ANSIBLE_CI_MANAGED_KEY, V2_ANSIBLE_CI_MANAGED_VALUE, V2_ANSIBLE_CI_IDENTIFIER_KEY, init_client_for_module, parse_delta, get_latest_resource
 
 
 try:
@@ -43,8 +42,13 @@ options:
             - A resource identifier for resources that have auto-generated uuids.
               The identifier gets stored in the resource labels.
               With this, the module can figure out if the resource already exists using the identifier label.
-              If multiple resources with the identifier label are found, the module acts on the latest created resource.
+              If multiple resources with the same identifier label are found, the module will throw an error.
         required: true
+    use_latest_identifier:
+        description:
+            - If set to true and multiple resources with the same identifier label are found, the module acts on the latest created resource.
+        required: true
+        default: false
     description:
         description:
             - The description of the token.
@@ -149,6 +153,8 @@ class Instance(object):
         self._uuid = None
         self._secret = None
         self._identifier = module.params.get('identifier')
+        self._use_latest_identifier = module.params.get(
+            'use_latest_identifier')
         self._user = module.params.get('user')
         self._description = module.params.get('description')
         self._expires = parse_delta(module.params.get(
@@ -201,22 +207,9 @@ class Instance(object):
                 msg="request to metal-apiserver failed", error=str(e))
             return
 
-        tokens = resp.tokens
-        if not tokens:
-            return
-
-        latest_created = None
-
-        for token in tokens:
-            if latest_created is None:
-                latest_created = token
-                continue
-
-            if token.meta.created_at.ToDatetime() > latest_created.meta.created_at.ToDatetime():
-                latest_created = token
-
-        self._token = latest_created
-        self._uuid = self._token.uuid
+        self._token = get_latest_resource(self, resp.tokens)
+        if self._token:
+            self._uuid = self._token.uuid
 
     def _update(self):
         r = token_pb2.TokenServiceUpdateRequest(
@@ -461,6 +454,7 @@ def main():
     argument_spec = V2_AUTH_SPEC.copy()
     argument_spec.update(dict(
         identifier=dict(type='str', required=True),
+        use_latest_identifier=dict(type='bool', default=False),
         user=dict(type='str', required=True),
         description=dict(type='str', required=False),
         expires=dict(type='str', required=False),

--- a/library/metal_v2_admin_token.py
+++ b/library/metal_v2_admin_token.py
@@ -40,9 +40,10 @@ description:
 options:
     identifier:
         description:
-            - A resource identifier for the created resource which must be unique within the managed resource scope for resources that have auto-generated uuids.
-              Otherwise, the module cannot figure out if the token was already created or not.
+            - A resource identifier for resources that have auto-generated uuids.
               The identifier gets stored in the resource labels.
+              With this, the module can figure out if the resource already exists using the identifier label.
+              If multiple resources with the identifier label are found, the module acts on the latest created resource.
         required: true
     description:
         description:
@@ -74,8 +75,7 @@ options:
         required: false
     labels:
         - The labels of the token.
-        - >-
-          Set to empty dict in order to clean existing.
+        - Set to empty dict in order to clean existing.
     required: false
     state:
         description:
@@ -202,17 +202,21 @@ class Instance(object):
             return
 
         tokens = resp.tokens
-
         if not tokens:
             return
 
-        if len(tokens) > 1:
-            self._module.fail_json(
-                msg="token description is not unique within the user, which is required when "
-                    "using this module", name=self._name)
-        elif len(tokens) == 1:
-            self._token = tokens[0]
-            self._uuid = self._token.uuid
+        latest_created = None
+
+        for token in tokens:
+            if latest_created is None:
+                latest_created = token
+                continue
+
+            if token.meta.created_at.ToDatetime() > latest_created.meta.created_at.ToDatetime():
+                latest_created = token
+
+        self._token = latest_created
+        self._uuid = self._token.uuid
 
     def _update(self):
         r = token_pb2.TokenServiceUpdateRequest(

--- a/library/metal_v2_api_token.py
+++ b/library/metal_v2_api_token.py
@@ -1,9 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from datetime import datetime
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.metal_v2 import V2_AUTH_SPEC, V2_ANSIBLE_CI_MANAGED_KEY, V2_ANSIBLE_CI_MANAGED_VALUE, V2_ANSIBLE_CI_IDENTIFIER_KEY, init_client_for_module, parse_delta
+from ansible.module_utils.metal_v2 import V2_AUTH_SPEC, V2_ANSIBLE_CI_MANAGED_KEY, V2_ANSIBLE_CI_MANAGED_VALUE, V2_ANSIBLE_CI_IDENTIFIER_KEY, init_client_for_module, parse_delta, get_latest_resource
 
 
 try:
@@ -42,8 +41,13 @@ options:
             - A resource identifier for resources that have auto-generated uuids.
               The identifier gets stored in the resource labels.
               With this, the module can figure out if the resource already exists using the identifier label.
-              If multiple resources with the identifier label are found, the module acts on the latest created resource.
+              If multiple resources with the same identifier label are found, the module will throw an error.
         required: true
+    use_latest_identifier:
+        description:
+            - If set to true and multiple resources with the same identifier label are found, the module acts on the latest created resource.
+        required: true
+        default: false
     description:
         description:
             - The description of the token.
@@ -146,6 +150,8 @@ class Instance(object):
         self._secret = None
         self._description = module.params.get('description')
         self._identifier = module.params.get('identifier')
+        self._use_latest_identifier = module.params.get(
+            'use_latest_identifier')
         self._expires = parse_delta(module.params.get(
             'expires')) if module.params.get('expires') else None
         self._project_roles = module.params.get('project_roles')
@@ -196,22 +202,9 @@ class Instance(object):
                 msg="request to metal-apiserver failed", error=str(e))
             return
 
-        tokens = resp.tokens
-        if not tokens:
-            return
-
-        latest_created = None
-
-        for token in tokens:
-            if latest_created is None:
-                latest_created = token
-                continue
-
-            if token.meta.created_at.ToDatetime() > latest_created.meta.created_at.ToDatetime():
-                latest_created = token
-
-        self._token = latest_created
-        self._uuid = self._token.uuid
+        self._token = get_latest_resource(self, resp.tokens)
+        if self._token:
+            self._uuid = self._token.uuid
 
     def _update(self):
         r = token_pb2.TokenServiceUpdateRequest(
@@ -443,6 +436,7 @@ def main():
     argument_spec = V2_AUTH_SPEC.copy()
     argument_spec.update(dict(
         identifier=dict(type='str', required=True),
+        use_latest_identifier=dict(type='bool', default=False),
         description=dict(type='str', required=False),
         expires=dict(type='str', required=False),
         permissions=dict(type='list', required=False, elements='dict', options=dict(

--- a/library/metal_v2_api_token.py
+++ b/library/metal_v2_api_token.py
@@ -39,9 +39,10 @@ description:
 options:
     identifier:
         description:
-            - A resource identifier for the created resource which must be unique within the managed resource scope for resources that have auto-generated uuids.
-              Otherwise, the module cannot figure out if the token was already created or not.
+            - A resource identifier for resources that have auto-generated uuids.
               The identifier gets stored in the resource labels.
+              With this, the module can figure out if the resource already exists using the identifier label.
+              If multiple resources with the identifier label are found, the module acts on the latest created resource.
         required: true
     description:
         description:
@@ -69,8 +70,7 @@ options:
         required: false
     labels:
         - The labels of the token.
-        - >-
-          Set to empty dict in order to clean existing.
+        - Set to empty dict in order to clean existing.
     state:
         description:
           - Assert the state of the token.
@@ -197,17 +197,21 @@ class Instance(object):
             return
 
         tokens = resp.tokens
-
         if not tokens:
             return
 
-        if len(tokens) > 1:
-            self._module.fail_json(
-                msg="token description is not unique within the user, which is required when "
-                    "using this module")
-        elif len(tokens) == 1:
-            self._token = tokens[0]
-            self._uuid = self._token.uuid
+        latest_created = None
+
+        for token in tokens:
+            if latest_created is None:
+                latest_created = token
+                continue
+
+            if token.meta.created_at.ToDatetime() > latest_created.meta.created_at.ToDatetime():
+                latest_created = token
+
+        self._token = latest_created
+        self._uuid = self._token.uuid
 
     def _update(self):
         r = token_pb2.TokenServiceUpdateRequest(

--- a/library/metal_v2_project.py
+++ b/library/metal_v2_project.py
@@ -39,9 +39,10 @@ description:
 options:
     identifier:
         description:
-            - A resource identifier for the created resource which must be unique within the managed resource scope for resources that have auto-generated uuids.
-              Otherwise, the module cannot figure out if the token was already created or not.
+            - A resource identifier for resources that have auto-generated uuids.
               The identifier gets stored in the resource labels.
+              With this, the module can figure out if the resource already exists using the identifier label.
+              If multiple resources with the identifier label are found, the module acts on the latest created resource.
         required: true
     name:
         description:
@@ -61,8 +62,7 @@ options:
         required: false
     labels:
         - The labels of the project.
-        - >-
-          Set to empty dict in order to clean existing.
+        - Set to empty dict in order to clean existing.
         required: false
     state:
         description:
@@ -180,17 +180,21 @@ class Instance(object):
             return
 
         projects = resp.projects
-
         if projects is None:
             return
 
-        if len(projects) > 1:
-            self._module.fail_json(
-                msg="project name is not unique within the tenant, which is required when "
-                    "using this module", name=self._name)
-        elif len(projects) == 1:
-            self._project = projects[0]
-            self._uuid = self._project.uuid
+        latest_created = None
+
+        for project in projects:
+            if latest_created is None:
+                latest_created = project
+                continue
+
+            if project.meta.created_at.ToDatetime() > latest_created.meta.created_at.ToDatetime():
+                latest_created = project
+
+        self._project = latest_created
+        self._uuid = self._project.uuid
 
     def _update(self):
         r = project_pb2.ProjectServiceUpdateRequest(

--- a/library/metal_v2_project.py
+++ b/library/metal_v2_project.py
@@ -1,9 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from datetime import datetime
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.metal_v2 import V2_AUTH_SPEC, V2_ANSIBLE_CI_MANAGED_KEY, V2_ANSIBLE_CI_MANAGED_VALUE, V2_ANSIBLE_CI_IDENTIFIER_KEY, init_client_for_module
+from ansible.module_utils.metal_v2 import V2_AUTH_SPEC, V2_ANSIBLE_CI_MANAGED_KEY, V2_ANSIBLE_CI_MANAGED_VALUE, V2_ANSIBLE_CI_IDENTIFIER_KEY, init_client_for_module, get_latest_resource
 
 
 try:
@@ -42,8 +41,13 @@ options:
             - A resource identifier for resources that have auto-generated uuids.
               The identifier gets stored in the resource labels.
               With this, the module can figure out if the resource already exists using the identifier label.
-              If multiple resources with the identifier label are found, the module acts on the latest created resource.
+              If multiple resources with the same identifier label are found, the module will throw an error.
         required: true
+    use_latest_identifier:
+        description:
+            - If set to true and multiple resources with the same identifier label are found, the module acts on the latest created resource.
+        required: true
+        default: false
     name:
         description:
             - The name of the project.
@@ -132,6 +136,8 @@ class Instance(object):
         self._uuid = None
         self._name = module.params['name']
         self._identifier = module.params.get('identifier')
+        self._use_latest_identifier = module.params.get(
+            'use_latest_identifier')
         self._description = module.params.get('description')
         self._avatar_url = module.params.get('avatar_url')
         self._tenant = module.params.get('tenant')
@@ -179,22 +185,9 @@ class Instance(object):
                 msg="request to metal-apiserver failed", error=str(e))
             return
 
-        projects = resp.projects
-        if projects is None:
-            return
-
-        latest_created = None
-
-        for project in projects:
-            if latest_created is None:
-                latest_created = project
-                continue
-
-            if project.meta.created_at.ToDatetime() > latest_created.meta.created_at.ToDatetime():
-                latest_created = project
-
-        self._project = latest_created
-        self._uuid = self._project.uuid
+        self._project = get_latest_resource(self, resp.projects)
+        if self._project:
+            self._uuid = self._project.uuid
 
     def _update(self):
         r = project_pb2.ProjectServiceUpdateRequest(
@@ -208,6 +201,7 @@ class Instance(object):
         if self._name and self._project.name != self._name:
             self.changed = True
             r.name = self._name
+
         if self._description and self._project.description != self._description:
             self.changed = True
             r.description = self._description
@@ -281,6 +275,7 @@ def main():
     argument_spec = V2_AUTH_SPEC.copy()
     argument_spec.update(dict(
         identifier=dict(type='str', required=True),
+        use_latest_identifier=dict(type='bool', default=False),
         name=dict(type='str', required=True),
         tenant=dict(type='str', required=True),
         description=dict(type='str', required=True),

--- a/library/metal_v2_tenant.py
+++ b/library/metal_v2_tenant.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.metal_v2 import V2_AUTH_SPEC, V2_ANSIBLE_CI_MANAGED_KEY, V2_ANSIBLE_CI_MANAGED_VALUE, V2_ANSIBLE_CI_IDENTIFIER_KEY, init_client_for_module
+from ansible.module_utils.metal_v2 import V2_AUTH_SPEC, V2_ANSIBLE_CI_MANAGED_KEY, V2_ANSIBLE_CI_MANAGED_VALUE, V2_ANSIBLE_CI_IDENTIFIER_KEY, init_client_for_module, get_latest_resource
 
 
 try:
@@ -41,8 +41,13 @@ options:
             - A resource identifier for resources that have auto-generated uuids.
               The identifier gets stored in the resource labels.
               With this, the module can figure out if the resource already exists using the identifier label.
-              If multiple resources with the identifier label are found, the module acts on the latest created resource.
+              If multiple resources with the same identifier label are found, the module will throw an error.
         required: true
+    use_latest_identifier:
+        description:
+            - If set to true and multiple resources with the same identifier label are found, the module acts on the latest created resource.
+        required: true
+        default: false
     name:
         description:
             - The name of the tenant.
@@ -128,6 +133,8 @@ class Instance(object):
         self._login = None
         self._name = module.params['name']
         self._identifier = module.params.get('identifier')
+        self._use_latest_identifier = module.params.get(
+            'use_latest_identifier')
         self._description = module.params.get('description')
         self._avatar_url = module.params.get('avatar_url')
         self._email = module.params.get('email')
@@ -175,22 +182,9 @@ class Instance(object):
                 msg="request to metal-apiserver failed", error=str(e))
             return
 
-        tenants = resp.tenants
-        if tenants is None:
-            return
-
-        latest_created = None
-
-        for tenant in tenants:
-            if latest_created is None:
-                latest_created = tenant
-                continue
-
-            if tenant.meta.created_at.ToDatetime() > latest_created.meta.created_at.ToDatetime():
-                latest_created = tenant
-
-        self._tenant = latest_created
-        self._login = self._tenant.login
+        self._tenant = get_latest_resource(self, resp.tenants)
+        if self._tenant:
+            self._login = self._tenant.login
 
     def _update(self):
         r = tenant_pb2.TenantServiceUpdateRequest(
@@ -276,6 +270,7 @@ def main():
     argument_spec = V2_AUTH_SPEC.copy()
     argument_spec.update(dict(
         identifier=dict(type='str', required=True),
+        use_latest_identifier=dict(type='bool', default=False),
         name=dict(type='str', required=True),
         description=dict(type='str', required=True),
         avatar_url=dict(type='str', required=False),

--- a/library/metal_v2_tenant.py
+++ b/library/metal_v2_tenant.py
@@ -38,9 +38,10 @@ description:
 options:
     identifier:
         description:
-            - A resource identifier for the created resource which must be unique within the managed resource scope for resources that have auto-generated uuids.
-              Otherwise, the module cannot figure out if the token was already created or not.
+            - A resource identifier for resources that have auto-generated uuids.
               The identifier gets stored in the resource labels.
+              With this, the module can figure out if the resource already exists using the identifier label.
+              If multiple resources with the identifier label are found, the module acts on the latest created resource.
         required: true
     name:
         description:
@@ -61,8 +62,7 @@ options:
     labels:
         description:
             - The labels of the tenant.
-            - >-
-              Set to empty dict in order to clean existing.
+            - Set to empty dict in order to clean existing.
         required: false
     state:
         description:
@@ -176,17 +176,21 @@ class Instance(object):
             return
 
         tenants = resp.tenants
-
         if tenants is None:
             return
 
-        if len(tenants) > 1:
-            self._module.fail_json(
-                msg="tenant identifier label is not unique, which is required when "
-                    "using this module", name=self._name)
-        elif len(tenants) == 1:
-            self._tenant = tenants[0]
-            self._login = self._tenant.login
+        latest_created = None
+
+        for tenant in tenants:
+            if latest_created is None:
+                latest_created = tenant
+                continue
+
+            if tenant.meta.created_at.ToDatetime() > latest_created.meta.created_at.ToDatetime():
+                latest_created = tenant
+
+        self._tenant = latest_created
+        self._login = self._tenant.login
 
     def _update(self):
         r = tenant_pb2.TenantServiceUpdateRequest(

--- a/module_utils/metal_v2.py
+++ b/module_utils/metal_v2.py
@@ -69,3 +69,28 @@ def parse_delta(delta) -> timedelta:
     else:
         raise RuntimeError(
             "unable to parse timedelta (may only contain minutes, hours and days), valid args look like 8h, 20d4h3m, ...")
+
+
+def get_latest_resource(self, resources):
+    if not resources:
+        return None
+
+    if self._use_latest_identifier:
+        latest_created = None
+
+        for resource in resources:
+            if latest_created is None:
+                latest_created = resource
+                continue
+
+            if resource.meta.created_at.ToDatetime() > latest_created.meta.created_at.ToDatetime():
+                latest_created = resource
+
+        return latest_created
+
+    if len(resources) != 1:
+        self._module.fail_json(
+            msg=f"the identifier label {V2_ANSIBLE_CI_IDENTIFIER_KEY}={self._identifier} does not return a unique resource. the module cannot figure out on which resource it is supposed to act on.")
+        return
+
+    return resources[0]


### PR DESCRIPTION
## Description

As discussed, this resolves the issue with refreshed tokens, which carry the same label again for the identifier.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
